### PR TITLE
Create(MercadoPago-condirmación)

### DIFF
--- a/client/src/Components/ShoppingCart/mercadoPago/MercadoPago.jsx
+++ b/client/src/Components/ShoppingCart/mercadoPago/MercadoPago.jsx
@@ -1,5 +1,11 @@
 import { React, useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import Container from 'react-bootstrap/Container';
+import Col from 'react-bootstrap/Col';
+import Row from 'react-bootstrap/Row';
+import imgMp from '../../../Assets/Images/combos/cajita-nuggetshamb-con-queso.png';
+
+import './mercadoPago.css';
 
 function MercadoPago() {
   const mercadopago = useSelector((state) => state.mercaDopago);
@@ -24,11 +30,28 @@ function MercadoPago() {
   };
 
   return (
-    <div>
-      <h1>Tu pedido esta casi listo!!!</h1>
-      <h2>Pulsa el siguiente boton para continuar</h2>
-      <form id="MP" method="GET" />
-    </div>
+    <Container>
+      <div className="mercadoPago__container">
+        <div className="mercadoPago__pay">
+          <h1 className="mecadoPago__tittle">
+            Estás a un paso de disfrutar tu
+            <span className="mercadoPago__span">Henry&apos;s Burger</span>
+          </h1>
+          <hr />
+          <p className="mercadoPago__text">
+            Pulsa el siguiente botón para continuar
+          </p>
+          <form id="MP" method="GET" />
+        </div>
+        <div className="mercadoPago__img">
+          <img
+            src={imgMp}
+            alt="Foto de dos hamburugesas y un balde de papas"
+            className="img-fluid"
+          />
+        </div>
+      </div>
+    </Container>
   );
 }
 

--- a/client/src/Components/ShoppingCart/mercadoPago/mercadoPago.css
+++ b/client/src/Components/ShoppingCart/mercadoPago/mercadoPago.css
@@ -1,0 +1,36 @@
+.mercadoPago__container {
+  display: flex;
+  align-items: center;
+  flex-direction: row-reverse;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin: 1.5rem 0 1.5rem 0;
+  min-height: 60vh;
+}
+
+.mercadoPago__img {
+  max-width: 500px;
+}
+
+.mercadoPago__pay {
+  background-color: var(--main-color-light);
+  padding: 2rem;
+  border-radius: 20px;
+  max-width: 350px;
+  box-shadow: var(--bs-card);
+}
+
+.mecadoPago__tittle {
+  font-size: 1.5rem;
+}
+
+.mercadoPago__text {
+  font-size: 0.9rem;
+}
+
+.mercadoPago__span {
+  font-weight: bolder;
+  color: var(--brand-color);
+  font-size: 1.9rem;
+  display: inline-block;
+}


### PR DESCRIPTION
Estilado del confirmación de pago de mercado pago, como no se puede cambiar el color del btn por defecto se agregó la imagen que tiene azúl para que combine.

![Captura de pantalla (156)](https://user-images.githubusercontent.com/6260385/182728502-b567954a-e7eb-43ec-ba82-b370c0638a54.png)
